### PR TITLE
Update validation for addition in permit.rb

### DIFF
--- a/app/models/permit.rb
+++ b/app/models/permit.rb
@@ -1,7 +1,8 @@
 class Permit < ActiveRecord::Base
   validates_presence_of :owner_address, :if => :active_or_address?, :message => "Please enter a San Antonio address."
-  validates :owner_address, :address => true, :if => :only_if_presence?
-  validates_numericality_of :addition_area, less_than: 1000, :if => :active_or_details?, :message => "Addition cannot be larger than 1000 Square Feet."
+  validates :owner_address, :address => true, :if => :only_if_address_presence?
+  validates_presence_of :addition_area, :if => :active_or_details?, :message => "Please enter the size of addition in square feet."
+  validates_numericality_of :addition_area, less_than: 1000, :if => :only_if_addition_presence?, :message => "Addition must be less than 1,000 Square Feet."
 
 
   def active?
@@ -12,11 +13,15 @@ class Permit < ActiveRecord::Base
     status.to_s.include?('enter_address') || active?
   end
 
-  def only_if_presence?
+  def only_if_address_presence?
     active_or_address? && ! owner_address.blank?
   end
 
   def active_or_details?
     status.to_s.include?('enter_details') || active?
+  end
+
+  def only_if_addition_presence?
+    active_or_details? && ! addition_area.blank?
   end
 end

--- a/app/views/permit_steps/enter_details.html.erb
+++ b/app/views/permit_steps/enter_details.html.erb
@@ -29,7 +29,7 @@
     <%= f.text_field :house_area, :required => true, class: "w-input", id: "SqFtHouse" %>
 
     <%= f.label :addition_area, "Size of addition in square feet*", for: "SqFtAddition" %>
-    <%= f.text_field :addition_area, :required => true, class: "w-input", id: "SqFtAddition" %>
+    <%= f.text_field :addition_area, class: "w-input", id: "SqFtAddition" %>
 
     <%= f.label :ac, "Air conditioning / heating system*", for: "air-conditioning-heating-system" %>
     <p class="label-explainer">Please select the type of temperature control system you plan to install in your addition.</p>


### PR DESCRIPTION
There was an issue earlier when nothing is entered on "Size of Addition in Square Feet", the error statement will mention "Addition cannot be larger than 1000 Square Feet", which does not make sense at all.

Now it is fixed, where if addition is not entered, an error message will say "Please enter the size of addition in square feet".

Also changed the statement when 1000 or more is entered, "Addition must be less than 1,000 Square Feet".
