### PR TITLE
Precompile flaticon/* vendor assets on Heroku production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,6 @@ Rails.application.configure do
 
   # Precompile vendor assets in production (for heroku)
 
-  config.assets.precompile += %w( flaticon/flaticon.css )
+  config.assets.precompile += %w( flaticon/* )
 
 end


### PR DESCRIPTION
This fixes a bug with the Heroku vendor asset pipeline. It adds the flaticon/\* folder so we can have our nice checkmark icons (and any other icons we put in there in the future).

[Fixes #72124228]
