### PR TITLE
Add Job Cost in permit info summary

### DIFF
--- a/app/views/permit_steps/display_summary.html.erb
+++ b/app/views/permit_steps/display_summary.html.erb
@@ -36,6 +36,7 @@
 
       <p><strong>Write the following information on the printed permit.</strong></p>
 
+      <p class="small-text"><b>Job Cost:</b> $<%= @permit.job_cost %></p>
       <p class="small-text"><b>Owner Name:</b> <%= @permit.owner_name %></p>
       <p class="small-text"><b>Owner Address:</b> <%= @permit.owner_address %></p>
 


### PR DESCRIPTION
Job Cost was missing the summary page, now added  back in.
