### PR TITLE
Add dollar sign form helper to job cost field

### DIFF
--- a/app/views/permit_steps/enter_details.html.erb
+++ b/app/views/permit_steps/enter_details.html.erb
@@ -226,7 +226,10 @@
             <p><%= @permit.errors.messages[:job_cost][0] %></p>
         <% end %>
 
-        <%= f.text_field :job_cost, class: "form-control input-lg", id: "job-cost" %>  
+        <div class="input-group">
+          <div class="input-group-addon">$</div>
+          <%= f.text_field :job_cost, class: "form-control input-lg", id: "job-cost" %>  
+        </div>
 
         <% if @permit.errors.messages[:job_cost].length >= 1 %>
           <!-- close the errors div -->


### PR DESCRIPTION
Pretty simple, adds a "$" before job costs. This is so users won't type one in. Also because we'll be printing one out on the generated PDF.
