### PR TITLE
Separate out all general repairs on the first page, currently disable en...

### DIFF
--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -9,12 +9,40 @@ $(document).ready(function()
       $(".panel-info-addition").toggleClass("panel-success")
     });
 
-  $(".pick-repair").click(function()
+  $(".pick-window").click(function()
     {
-      $(".repair").fadeToggle("fast","swing");
-      $(".pick-repair").toggleClass("btn-success");
-      $(".panel-info-repair").toggleClass("panel-success")
+      $(".window").fadeToggle("fast","swing");
+      $(".pick-window").toggleClass("btn-success");
+      $(".panel-info-window").toggleClass("panel-success")
     });  
+
+  $(".pick-door").click(function()
+    {
+      $(".door").fadeToggle("fast","swing");
+      $(".pick-door").toggleClass("btn-success");
+      $(".panel-info-door").toggleClass("panel-success")
+    }); 
+
+  $(".pick-wall").click(function()
+    {
+      $(".wall").fadeToggle("fast","swing");
+      $(".pick-wall").toggleClass("btn-success");
+      $(".panel-info-wall").toggleClass("panel-success")
+    }); 
+
+  $(".pick-siding").click(function()
+    {
+      $(".siding").fadeToggle("fast","swing");
+      $(".pick-siding").toggleClass("btn-success");
+      $(".panel-info-siding").toggleClass("panel-success")
+    }); 
+
+  $(".pick-floor").click(function()
+    {
+      $(".floor").fadeToggle("fast","swing");
+      $(".pick-floor").toggleClass("btn-success");
+      $(".panel-info-floor").toggleClass("panel-success")
+    }); 
 
   $(".pick-cover").click(function()
     {

--- a/app/controllers/permit_steps_controller.rb
+++ b/app/controllers/permit_steps_controller.rb
@@ -7,7 +7,8 @@ class PermitStepsController < ApplicationController
   include PermitParams
 
   include Wicked::Wizard
-  steps :enter_address, :display_permits, :enter_details, :enter_addition, :enter_repair, :display_summary
+  steps :enter_address, :display_permits, :enter_details, :enter_addition, #:enter_repair, 
+        :display_summary
   
   def show
     @permit = current_permit
@@ -17,8 +18,9 @@ class PermitStepsController < ApplicationController
     when :enter_addition
       skip_step if @permit.addition == nil || !@permit.addition
 
-    when :enter_repair
-      skip_step if @permit.repair == nil || !@permit.repair
+    # @TODO: Will take out completely when David put everything in 1 page
+    # when :enter_repair
+    #  skip_step if (!@permit.window || !@permit.door || !@permit.wall || !@permit.siding || !@permit.floor)
 
     when :display_summary
       pdftk = PdfForms.new('pdftk')
@@ -50,7 +52,11 @@ class PermitStepsController < ApplicationController
                                                     
                                                     'CARPORT_COVER_CHECKBOX'  => @permit.cover ? "X" : ' ',
 
-                                                    'GENERAL_REPAIRS_CHECKBOX'  => @permit.repair ? "X" : ' ',
+                                                    'GENERAL_REPAIRS_CHECKBOX'  => (@permit.window ||
+                                                                                    @permit.door ||
+                                                                                    @permit.wall ||
+                                                                                    @permit.siding ||
+                                                                                    @permit.floor) ? "X" : ' ',
                                                     'WINDOWS_CHECKBOX'          => @permit.window ? "X" : ' ',
                                                     'NUMBER_WINDOWS'            => @permit.window_count,
                                                     'DOORS_CHECKBOX'            => @permit.door ? "X" : ' ',

--- a/app/views/permit_steps/display_summary.html.erb
+++ b/app/views/permit_steps/display_summary.html.erb
@@ -44,7 +44,6 @@
     <div class="panel-body">
       <%= image_tag "general-repairs-template-signhere.png", width: "100%" %>
       <p>After you've printed your permit, sign your name in the appropriate field.</p>
-      <p><%#= @field_names %>
     </div><!-- panel-body -->
   </div><!-- ./panel -->
 

--- a/app/views/permits/new.html.erb
+++ b/app/views/permits/new.html.erb
@@ -38,17 +38,65 @@
       </div>
       <!-- ./addition -->
 
-      <!-- Pick and option: REPAIRS -->
-      <div class="panel panel-default panel-info-repair">
-        <div class="panel-heading"><h4>General Repairs</h4></div>
+      <!-- Pick and option: WINDOW -->
+      <div class="panel panel-default panel-info-window">
+        <div class="panel-heading"><h4>Windows</h4></div>
         <div class="panel-body">
           <%= image_tag "#", class: 'hidden-xs' %>
-          <p>General repairs are changes you make to your current home, like adding a new window, door, walls, siding, and floor.</p>
-          <%= f.label :repair, "I want to make a general repair", class: 'btn btn-default btn-small pick-repair'%>
-          <%= f.check_box :repair, style: 'display:none;' %>
+          <p>Replace windows.</p>
+          <%= f.label :window, "I want to change window", class: 'btn btn-default btn-small pick-window'%>
+          <%= f.check_box :window, style: 'display:none;' %>
         </div>
       </div>
-      <!-- ./repair -->
+      <!-- ./window -->
+
+      <!-- Pick and option: DOOR -->
+      <div class="panel panel-default panel-info-door">
+        <div class="panel-heading"><h4>Doors</h4></div>
+        <div class="panel-body">
+          <%= image_tag "#", class: 'hidden-xs' %>
+          <p>Replace doors.</p>
+          <%= f.label :door, "I want to change door", class: 'btn btn-default btn-small pick-door'%>
+          <%= f.check_box :door, style: 'display:none;' %>
+        </div>
+      </div>
+      <!-- ./door -->
+
+      <!-- Pick and option: WALL -->
+      <div class="panel panel-default panel-info-wall">
+        <div class="panel-heading"><h4>Walls</h4></div>
+        <div class="panel-body">
+          <%= image_tag "#", class: 'hidden-xs' %>
+          <p>Replace walls.</p>
+          <%= f.label :wall, "I want to change wall", class: 'btn btn-default btn-small pick-wall'%>
+          <%= f.check_box :wall, style: 'display:none;' %>
+        </div>
+      </div>
+      <!-- ./wall -->
+
+      <!-- Pick and option: SIDING -->
+      <div class="panel panel-default panel-info-siding">
+        <div class="panel-heading"><h4>Sidings</h4></div>
+        <div class="panel-body">
+          <%= image_tag "#", class: 'hidden-xs' %>
+          <p>Replace sidings.</p>
+          <%= f.label :siding, "I want to change siding", class: 'btn btn-default btn-small pick-siding'%>
+          <%= f.check_box :siding, style: 'display:none;' %>
+        </div>
+      </div>
+      <!-- ./siding -->
+
+      <!-- Pick and option: FLOOR -->
+      <div class="panel panel-default panel-info-floor">
+        <div class="panel-heading"><h4>Floors</h4></div>
+        <div class="panel-body">
+          <%= image_tag "#", class: 'hidden-xs' %>
+          <p>Replace floors.</p>
+          <%= f.label :floor, "I want to change floor", class: 'btn btn-default btn-small pick-floor'%>
+          <%= f.check_box :floor, style: 'display:none;' %>
+        </div>
+      </div>
+      <!-- ./floor -->
 
       <!-- Pick and option: COVER -->
       <div class="panel panel-default panel-info-cover">

--- a/db/migrate/20140705221829_remove_repair_to_permits.rb
+++ b/db/migrate/20140705221829_remove_repair_to_permits.rb
@@ -1,0 +1,5 @@
+class RemoveRepairToPermits < ActiveRecord::Migration
+  def change
+    remove_column :permits, :repair, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140705213642) do
+ActiveRecord::Schema.define(version: 20140705221829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,6 @@ ActiveRecord::Schema.define(version: 20140705213642) do
     t.datetime "updated_at"
     t.integer  "job_cost"
     t.string   "status"
-    t.boolean  "repair"
     t.boolean  "window"
     t.boolean  "door"
     t.boolean  "wall"

--- a/lib/permit_params.rb
+++ b/lib/permit_params.rb
@@ -22,7 +22,6 @@ module PermitParams
     :work_summary,
     :job_cost,
     :status,
-    :repair,
     :window,
     :door,
     :wall,


### PR DESCRIPTION
Separate out all general repairs on the first page
currently disable enter_repair page, and will be somewhat broken right now because cannot get number of windows/doors at this point until all details are on one page
