### PR TITLE
Suppress ActiveRecord logs in Test Logs

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Print only warn/error/fatal/unkown on stdout
+  config.log_level = :warn
+
 end


### PR DESCRIPTION
ActiveRecords are outputting too much information in the test environment.  It prevents developers to see important information in test outputs.  Log level is changed to "warn" to suppress "info" from overwhelming the logs.
