### PR TITLE
PDF Link Issue

### DIFF
--- a/app/controllers/permit_steps_controller.rb
+++ b/app/controllers/permit_steps_controller.rb
@@ -116,10 +116,10 @@ class PermitStepsController < ApplicationController
 
   def serve
     # path = "#{Rails.root}/tmp/#{params[:filename]}.pdf"
-    @permit = current_permit
+    # @permit = current_permit
     # find permit details 
-    permit_binary_detail = PermitBinaryDetail.find_by permit_id: @permit.id
-
+    #permit_binary_detail = PermitBinaryDetail.find_by permit_id: @permit.id
+    permit_binary_detail = PermitBinaryDetail.find_by filename: "#{params[:filename]}.pdf"
     if permit_binary_detail
       send_data(permit_binary_detail.binary.data,
                 :disposition => 'inline',


### PR DESCRIPTION
Fix PDF link issue, before the PDF link only can be used within session.  Once a session has ended, you will not be able to get to it.  But it can now serve any PDF as long as you have the link.
