### PR TITLE
remove extra question for deck on screener page

### DIFF
--- a/app/views/permit_steps/answer_screener.html.erb
+++ b/app/views/permit_steps/answer_screener.html.erb
@@ -103,13 +103,6 @@
                                                                       { value: 'notAttachedToDwelling', 
                                                                         label: "Not attached to dwelling" }]} %>
 
-          <%= render partial: "screener_question", locals: {f: f, 
-                                                            question: "Dwelling Attachment", 
-                                                            attribute: :deck_grade, 
-                                                            option: [ { value: 'attachedToDwelling', 
-                                                                        label: "Attached to dwelling" }, 
-                                                                      { value: 'notAttachedToDwelling', 
-                                                                        label: "Not attached to dwelling" }]} %>
 
           <%= render partial: "screener_question", locals: {f: f, 
                                                             question: "Exit Door", 


### PR DESCRIPTION
There is a duplicate question on the screener page on the "attached to dwelling" for the deck.  That needed to be removed.
