### PR TITLE
Fix crashing issues when nothing is entered on enter_details step

### DIFF
--- a/app/controllers/permit_steps_controller.rb
+++ b/app/controllers/permit_steps_controller.rb
@@ -127,7 +127,9 @@ class PermitStepsController < ApplicationController
       session[:permit_needs] = @permit.update_permit_needs_for_projects
 
     when :enter_details
-
+      # Need to show ac options if errors occur
+      @permit_ac_options = Permit::AC_OPTIONS
+      
       # This will limit the number of times Geocoder is called as there is a 
       # limit on the number of times this is being called per day
       # @TODO: May want to make all caps comparison so to prevent case sensitive issue"

--- a/app/views/permit_steps/form_helper/_select.html.erb
+++ b/app/views/permit_steps/form_helper/_select.html.erb
@@ -14,7 +14,7 @@
   <% if helper_text %>
     <p class="help-block"><%= helper_text %></p>
   <% end %>
-
+  
   <% if model_attribute.blank? %>
     <%= f.select  attribute, 
                   options_for_select(options), 


### PR DESCRIPTION
AC options were not included when generating the update enter_details step.  So when errors occurred, options become empty and it crashed.
